### PR TITLE
docs: update README to not run Selenium tests until QA is ready.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Otherwise, the repo belongs in Pearson BitBucket, for which you should already h
 
     git push -u origin master
 
+5. Turn off Selenium testing until ready for QA to begin that effort.
+	1. Open ./.travis.yml
+	2. Comment out line 8
+	3. Save and close.
 ## Ready to Develop
 
 After completing the above steps, delete this README and rename [README.main.md](README.main.md) as "README.md" for


### PR DESCRIPTION
At Eajaz's request, I have added to the documentation to comment out the execution of the ./test/shell_scripts/run_tests.sh file which runs the Selenium testing.  When component development is ready for QA, he will re-enable that script.