### PR TITLE
Node Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- 4.2
+- 4
+- 6
 script:
 - npm run ci
 - chmod 777 ./test/shell_scripts/run_tests.sh

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdom": "~8.5.0",
     "json-loader": "~0.5.4",
     "mocha": "~2.4.5",
-    "node-sass": "~3.4.2",
+    "node-sass": "~3.7.0",
     "pearson-elements": "^0.12.0",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",


### PR DESCRIPTION
Console is upgrading to Node version 6 for PaaS, so it would be helpful to make sure our stuff works (in TravisCI) on it. For example, they should be confident in contributing Origami components without having to switch Node versions while developing it.

Haven't yet seen a way to CI on multiple versions of Node in Solano, however.