### PR TITLE
refactor: Change the main in package.json to point to the built bundl…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,12 @@
 .eslintrc
 .idea
 .travis.yml
+solano.yml
 build/.gitkeep
 build/dev*
 npm_scripts
 webpack.config.js
 test
+demo
+fonts
+main.js

--- a/README.usage.md
+++ b/README.usage.md
@@ -31,42 +31,24 @@ If your browser already supports a feature, this service automatically optimizes
 
 See the /demo directory for example usage.
 
-Both the component's original source code and the transpiled UMD bundle are available in the npm installation.
-
-Use the source when you want to use this project as a sub-component dependency that is referenced in the JSX of your 
-parent component.
-
-Use the bundled version when you want to drop in the component on your page and instantiate in a DOM element.
-     
-### Bundle (Simplest)
-
-The transpiled, minified bundle will be available in /node_modules in the component /build directory.
+The transpiled, minified bundle will be available in /node_modules/@pearson-components in the component 
+/build directory after you have npm installed this component in your project.
 
 Eventing example:
 
 ```js
-[EXAMPLE GOES HERE]
+[EVENTING EXAMPLE GOES HERE]
 ```
 
-### or Build
-
-There are use cases where you might need to roll the component into your application's build process.
-
-CommonJS example:
+Direct API example:
 
 ```js
-[EXAMPLE GOES HERE]
-```
-
-Example webpack configuration (requires correct configuration and installation of loader dependencies):
-
-```js
-[EXAMPLE GOES HERE]
+[DIRECT API EXAMPLE GOES HERE]
 ```
     
 ### Component Configuration
 
-    [CONFIG EXAMPLE GOES HERE]
+    [CONFIG INFO GOES HERE]
 
 ### Eventing
 

--- a/main.js
+++ b/main.js
@@ -2,9 +2,6 @@
 // Change all references to 'MyComponent' in this file to your real component name!
 //
 
-// bundled component styling
-import './main.scss';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ComponentOwner from './src/js/component-owner';

--- a/main.scss
+++ b/main.scss
@@ -1,3 +1,0 @@
-@import 'src/scss/variables';
-@import 'src/scss/mixins';
-@import 'src/scss/component-specific';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "",
   "version": "0.0.0",
   "description": "",
-  "main": "./main.js",
+  "main": "./build/dist.component-name.js",
   "scripts": {
     "dev-setup": "node ./npm_scripts/dev-setup.js",
     "dev": "node ./npm_scripts/dev.js",

--- a/src/js/component-owner.js
+++ b/src/js/component-owner.js
@@ -1,8 +1,10 @@
 // In React, an owner is the component that sets the props of other components, if desired.
 // (see https://facebook.github.io/react/docs/multiple-components.html)
 //
-// NOTE: If this is a sub-component for another Origami component, import this file in that project rather than this
-// project's main.js.
+// NOTE: If you want to reference another Origami component in this file's JSX below, import
+// it's src/js/component-owner.js directly from this project's /node_modules.
+
+import '../scss/component-specific.scss';
 
 import React, {PropTypes} from 'react';
 import {intlShape, injectIntl} from 'react-intl';

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,3 +1,0 @@
-////
-/// Custom SCSS mixins for component-specific styling go here
-////

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,3 +1,0 @@
-////
-/// Custom SCSS variables for component-specific styling go here
-////


### PR DESCRIPTION
…e so that the source is not required to be published to npm, and the consumer is not required to build it to use the component's direct API.

Additionally, eliminated some scss cruft that most components won't need. If they need it, they can add it themselves.

@umahaea Please confirm this won't impact automated testing.