### PR TITLE
fix: Ignore component-specific styles for unit testing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-intl": "~2.0.1"
   },
   "devDependencies": {
-    "@pearson-components/npm-scripts": "^0.3.1",
+    "@pearson-components/npm-scripts": "^0.3.2",
     "babel-core": "~6.3.17",
     "babel-eslint": "~4.1.6",
     "babel-loader": "~6.2.0",
@@ -45,6 +45,7 @@
     "expect": "~1.18.0",
     "expect-jsx": "~2.5.1",
     "file-loader": "~0.8.5",
+    "ignore-styles": "~5.0.1",
     "intl": "~1.1.0",
     "jsdom": "~8.5.0",
     "json-loader": "~0.5.4",


### PR DESCRIPTION
When I moved the import of the component-specific.scss into component-owner.js from main.js - it means that mocha barfs on scss. Thanks to @JasonLantz for finding this. This fix ignores those imports because style testing is better left to automated testing by selenium.