### PR TITLE
fix: Solano configuration needs to call copy-utils script like Travis…

### DIFF
--- a/README.contribute.md
+++ b/README.contribute.md
@@ -56,6 +56,7 @@ See the project working before changing anything!
 In your local repo:
 
     npm install
+    npm run copy-utils
     npm run dev
 
 Navigate to: **localhost:8081/demo** 

--- a/README.contribute.md
+++ b/README.contribute.md
@@ -56,7 +56,6 @@ See the project working before changing anything!
 In your local repo:
 
     npm install
-    npm run copy-utils
     npm run dev
 
 Navigate to: **localhost:8081/demo** 

--- a/solano.yml
+++ b/solano.yml
@@ -6,6 +6,7 @@ nodejs:
 hooks:
   pre: npm install
 tests:
+- npm run copy-utils
 - npm run ci
 - chmod 777 ./test/shell_scripts/run_tests.sh
 #- ./test/shell_scripts/run_tests.sh


### PR DESCRIPTION
… config. The dev doesn't need to because it is part of the dev-setup script.