### PR TITLE
fix: jest env to jsdom, add mocking for styles and files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
       "js",
       "json"
     ],
+    "moduleNameMapper" : {
+      "^.+\\.(css|scss)$" : "<rootDir>/test/__mocks__/styleMock.js",
+      "^.+\\.(gif|ttf|eot|svg|png)$": "<rootDir>/test/__mocks__/fileMock.js"
+    },
     "collectCoverageFrom": [
       "**/src/js/*.{js,jsx}"
     ],
@@ -39,7 +43,6 @@
     "testPathIgnorePatterns": [
       "<rootDir>/(build|node_modules|demo|coverage)/"
     ],
-    "testEnvironment": "node",
     "verbose": true
   },
   "devDependencies": {

--- a/test/__mocks__/fileMock.js
+++ b/test/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/__mocks__/styleMock.js
+++ b/test/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
this allows mocking for style sheets, and sets the jest env to the default jsdom....