### PR TITLE
fix: disableHostCheck on webpack for VM issues

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = {
     https              : false,
     overlay            : true,
     watchContentBase   : true,
+    disableHostCheck   : true,
     historyApiFallback : true,
     watchOptions       : { poll: true },
     contentBase        : path.join(__dirname, "build")


### PR DESCRIPTION
for some reason i couldn't pull up localhost on my Windows vm.... this disables the host check on webpack and allows vm access at http://10.0.2.2:<port>/<component>